### PR TITLE
[WIP] Supply and reserves feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,52 @@
-# Proof of Reserve
+# Proof of Reserve (POC)
 
-### Todo
-- [ ] governance system
-
+ ⚠️ This codebase has not been audited, might contain bugs and should not be used in production. ⚠️
+ 
 # Introduction
 
-With the massive adoption of crypto and activity generally related to the financial market (trading, lending, swapping, borrowing) users are eager to know if the assets they have on the platforms are not just numbers without values. Proof of Reserve comes with the ambition to allow transparency since point-in-time attestation can be manipulated and cash flow analysis . PoR allows users to conduct audit digital assets reserves while custodians (exchange, DeFi protocol) gain the trust of users
+With the massive adoption of crypto and activity generally related to the financial market (trading, lending, swapping, borrowing) users are eager to know if the assets they have on the platforms are not just numbers without values. Proof of Reserve comes with the ambition to allow transparency since point-in-time attestation can be manipulated and cash flow analysis. PoR allows users to conduct audit on digital assets reserves while custodians (exchange, DeFi protocol) gain the trust of users. Another advantage worth mentioning is that PoR is also an appealing prospect for regulators as this self-regulating measure is in line with their overarching vision for the industry.
 
-# How it works
 
-During Proof of Reserve, a third party takes a snapshot of the balances and generate a merkle root after passing the balance to a merkle tree, this cryptographic structure allows privacy and transparency . Kraken and Chainlink have an implementation of PoR 
+ # How PoR works?
+ 
+A Merkle root is obtained after the data has been processed via the Merkle tree by the third-party auditor during the Proof of Reserves process. The Merkle root is used to create a cryptographic fingerprint that represents the combination of the balances. In terms of cryptography, the tree's root acts as a "commitment scheme," i.e., a commitment that discloses the leaf nodes to be a part of the initial commitment. The auditors utilize this during Proof of Reserves (PoR) to confirm the balances. Several data samples are compared to the Merkle root. Auditors can detect any tampering with the data since even a little modification to the data impacts the Merkle root.
 
-**what is Merkle tree ?**
-In cryptography, a hash tree or Merkle tree is a tree in which every leaf node is labelled with the cryptographic hash of a data block, and every non-leaf node is labelled with the hash of the labels of its child nodes. Hash trees allow efficient and secure verification of the contents of large data structures.
+# ****Our Solution****
 
-**Kraken Case**
-The auditor then collects digital signatures produced by Kraken, which prove ownership over the on-chain addresses with publicly verifiable balances. Lastly, the auditor compares and verifies that these balances exceed or match the client balances represented in the Merkle tree, and therefore that the client assets are held on a full-reserve basis.
 
-![Untitled](https://www.notion.so/image/https%3A%2F%2Fs3-us-west-2.amazonaws.com%2Fsecure.notion-static.com%2Fda765df6-fa29-4b4e-81d6-88b4b7e5cb8a%2FUntitled.png?table=block&id=c2e3703e-c447-43d9-aea5-7431a6d909f4&spaceId=703c9ac7-6b4a-4c85-a4d6-c178cba99965&width=2000&userId=dd8e8ef1-9abd-4bd5-a553-060b5655d4f9&cache=v2)
+![por](https://user-images.githubusercontent.com/37840702/199752841-beccc187-c90b-49b4-821e-725db3a1bb33.png)
 
-**Chainlink Case**
 
-Chainlink provides  smart contracts with the data needed to calculate collateralization  on multi chain or backed off chain. using his decentralized oracle network , autonomous audits can be conducts and automated by anyone . while traditional implementations of PoR like kraken and centralized exchanges use collateralization of token currently on the cryptocurrency ecosystem, chainlink PoR can bring transparency to any asset that has been brought on-chain, it could be real estates, NFT etc .  
 
-![Untitled](https://www.notion.so/image/https%3A%2F%2Fs3-us-west-2.amazonaws.com%2Fsecure.notion-static.com%2F889e6552-3ef7-4cd5-8712-f0ca54524143%2FUntitled.png?table=block&id=a5d0a4f0-5ea1-4062-8b36-0b9b4c669e01&spaceId=703c9ac7-6b4a-4c85-a4d6-c178cba99965&width=2000&userId=dd8e8ef1-9abd-4bd5-a553-060b5655d4f9&cache=v2)
+
+The main components of the system can be broken down into the bridge oracles, aggregators (both on Ethereum & Starknet) & Starknet Oracles.
+
+
+**Starknet Aggregator**
+
+Keeps track of all the rounds & answers received from mainnet aggregator on the reserves of each known asset. The Starknet aggregator also receives feeds from Oracles on assets total supply on Starknet. 
+
+To call the aggreagtor Dapp contracts need to call the main two functions:
+
+
+```get_latest_reserves``` : returns publisher address, timestamp & the asset resereves value
+
+
+```get_latest_supply``` : returns publisher address, timestamp & the asset supply value
+
+
+**Starknet Oracles**
+
+Oracles that keep track of assets supplies on Starknet
+
+**Ethereum<>Starknet Bridges Oracles** 
+![por_oracle](https://user-images.githubusercontent.com/37840702/199755200-c35858f2-9a48-4591-a759-6b8a866b1bcd.png)
+
+The Ethereum<>Starknet Oracles are responsible for the feeds on the balance of collateralized assets held on Starknet bridges. A storage proof is provided to the aggregator, the storage value for the balance of each of the underying asset is then computed and the total reserves/collateral value is sent the Starknet Aggregator. 
+
 
 # ****Shortcomings****
+
 
 While PoR is adopting more and more on-chain, there are some shortcomings identifies 
 
@@ -35,26 +56,18 @@ While PoR is adopting more and more on-chain, there are some shortcomings identi
 
 • The auditor must be competent and independent to minimize the risk of duplicity on the part of the audit, or collusion amongst the parties.
 
-while Chainlink seems to offer a more decentralized solution, it is not present in the starknet chain , a solution would be to develop a special solution with the different oracles present on starkent such as stork, point or empiric network .  Proof of Reserve is a real time audit service where user can verify digital assets reserve on-chain or off-chain, we have some questions to understand since chainlink solution is not available for starknet ,
+while Chainlink seems to offer a more decentralized solution, it is not present in the starknet chain, a solution would be to develop a special solution with the different oracles present on starkent such as stork, point or empiric network .  Proof of Reserve is a real time audit service where user can verify digital assets reserve on-chain or off-chain, we have some questions to understand since chainlink solution is not available for starknet ,
 
 - How decentralized are the oracles solution present on starknet ?
 - Where will we select the data to feed the oracle ?
 
+# Roadmap
 
-# ***Process***
+- [ ] Add governance contracts
+- [ ] Build oracles
 
-Implementing a decentralized solution implies having secure data. from the ethereum network it must be possible to sign messages according to ethereum standards ```b'\x19Ethereum Signed Message:\n32'``` and decode it from starknet side .
 
 
-![Untitled](https://www.notion.so/image/https%3A%2F%2Fs3-us-west-2.amazonaws.com%2Fsecure.notion-static.com%2Faffd96f6-155a-439c-bae3-d1c2d0124e1f%2FScreen_Shot_2022-09-26_at_21.51.58.png?table=block&id=d9e2adba-87d2-40a1-87f6-1307b08a68a3&spaceId=703c9ac7-6b4a-4c85-a4d6-c178cba99965&width=2000&userId=dd8e8ef1-9abd-4bd5-a553-060b5655d4f9&cache=v2)
-
-```
-1- Trusted Entity sign message containing address, balance , asset to the Ethereum smart contract
-2- A chainlink keeper attached to the ethereum main smart contract emits at a defined period of time the order to send transaction to the starknet side .
-3- The datas are batched and sent to the starknet via the messaging contract L1->L2
-4- The signatures are verified by the starnet smart contracts and merkle root is updated. 
-5- User can verify if an address held the amount that proclaims
-```
 
 ## Get started
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 With the massive adoption of crypto and activity generally related to the financial market (trading, lending, swapping, borrowing) users are eager to know if the assets they have on the platforms are not just numbers without values. Proof of Reserve comes with the ambition to allow transparency since point-in-time attestation can be manipulated and cash flow analysis. PoR allows users to conduct audit on digital assets reserves while custodians (exchange, DeFi protocol) gain the trust of users. Another advantage worth mentioning is that PoR is also an appealing prospect for regulators as this self-regulating measure is in line with their overarching vision for the industry.
 
 
- # How PoR works?
+ # How Proof of reserve works?
  
 A Merkle root is obtained after the data has been processed via the Merkle tree by the third-party auditor during the Proof of Reserves process. The Merkle root is used to create a cryptographic fingerprint that represents the combination of the balances. In terms of cryptography, the tree's root acts as a "commitment scheme," i.e., a commitment that discloses the leaf nodes to be a part of the initial commitment. The auditors utilize this during Proof of Reserves (PoR) to confirm the balances. Several data samples are compared to the Merkle root. Auditors can detect any tampering with the data since even a little modification to the data impacts the Merkle root.
 
@@ -73,7 +73,7 @@ while Chainlink seems to offer a more decentralized solution, it is not present 
 
 **Clone this repo**
 
-```git clone https://github.com/joshualyguessennd/PoR```
+```git clone https://github.com/joshualyguessennd/ProofReserve-Starknet```
 
 # Environnment 
 
@@ -87,6 +87,7 @@ nvm use 16
 
 **Install**
 ```
+cd ProofReserve-Starknet
 python -m venv .venv
 source .venv/bin/activate
 pip install cairo-lang

--- a/contracts/ethereum/PublishDataL1.sol
+++ b/contracts/ethereum/PublishDataL1.sol
@@ -62,19 +62,14 @@ contract PublishDataL1 {
     }
 
     /**
-     *@param asset_symbol symbol of asset
-     *@param asset_name name of the asset
-     *@param _account address that owns the asset
-     *@param public_key address public_key , this only works for the poc,
-     *dev can adapt, remove by generating new signature with own address to test the contract
-     *@param account_balance amount of asset address owns
+     *@param asset address
+     *@param reserves the total of collateralized assets
+     *@param publicKey address public_key , this only works for the poc,
      */
     function publishData(
-        uint256 asset_symbol,
-        uint256 asset_name,
-        address _account,
-        uint256 account_balance,
-        uint256 public_key,
+        address asset,
+        uint256 reserves,
+        uint256 publicKey,
         bytes32 r,
         bytes32 s,
         uint8 v
@@ -83,23 +78,17 @@ contract PublishDataL1 {
             revert IsNotPublisher();
         }
         uint256[] memory payload = new uint256[](11);
-        uint256 sym = asset_symbol;
-        uint256 asset = asset_name;
-        uint256 address_account = uint256(uint160(_account));
         uint256 _r = uint256(r);
         uint256 _s = uint256(s);
         // send payload
-        payload[0] = sym;
-        payload[1] = asset;
-        payload[2] = address_account;
-        payload[3] = account_balance;
-        payload[4] = block.timestamp;
-        (payload[5], payload[6]) = toSplitUint(_r);
-        (payload[7], payload[8]) = toSplitUint(_s);
+        payload[0] = uint256(uint160(asset));
+        payload[1] = reserves;
+        (payload[2], payload[3]) = toSplitUint(_r);
+        (payload[4], payload[5]) = toSplitUint(_s);
         // v
-        payload[9] = v;
+        payload[6] = v;
         // payload[10] = uint256(uint160(address(address(this))));
-        payload[10] = public_key;
+        payload[7] = publicKey;
         // store the data for the next round
         data[msg.sender] = DataInfo(msg.sender, payload);
     }

--- a/contracts/starknet/proof_reserve.cairo
+++ b/contracts/starknet/proof_reserve.cairo
@@ -9,12 +9,22 @@ from starkware.cairo.common.hash import hash2
 from starknet.signature_verification import verify_signature, word_reverse_endian_64
 from starkware.cairo.common.math_cmp import is_le_felt
 
+struct Round {
+    publisher: felt,
+    reserves: felt,
+    timestamp: felt,
+}
+
 @storage_var
 func contract_admin() -> (res: felt) {
 }
 
 @storage_var
-func roots(public_key: felt, asset: felt, balance: felt, timestamp: felt) -> (res: felt) {
+func reserves_rounds(asset: felt, id: felt) -> (data: Round ) {
+}
+
+@storage_var
+func supplies_rounds(asset: felt, id: felt) -> (data: Round ) {
 }
 
 @storage_var
@@ -69,10 +79,8 @@ func post_data{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
 }(
     from_address: felt, 
-    asset_sym: felt,
-    asset_name: felt,
-    address_owner: felt,
-    balance: felt,
+    asset:felt,
+    reserves:felt,
     timestamp: felt,
     r_low: felt,
     r_high: felt,
@@ -91,10 +99,8 @@ func post_data{
     // // verify the signature of the sources
     with_attr error_message("Signature verification failed") {
         verify_signature(
-           asset_sym,
-            asset_name,
-            address_owner,
-            balance,
+           asset,
+            reserves,
             r_low,
             r_high,
             s_low,
@@ -103,19 +109,18 @@ func post_data{
             public_key,
         );
     }
-    let (root_) = calc_hash(0, 4, new(address_owner, asset_name, balance, timestamp));
-    roots.write(address_owner, asset_name, balance, timestamp, root_);
-    return ();
+    let round = Round(public_key ,reserves, timestamp);
+ 
+    reserves_rounds.write(asset, 1, round);
+    return (); 
 }
 
 @external
-func post_data_l2{
+func publish_l2_supply{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
 }(  
-    asset_sym: felt,
-    asset_name: felt,
-    address_owner: felt,
-    balance: felt,
+    asset:felt,
+    supply: felt,
     timestamp: felt,
     r_low: felt,
     r_high: felt,
@@ -134,10 +139,8 @@ func post_data_l2{
     // verify the signature of the sources
     with_attr error_message("Signature verification failed") {
         verify_signature(
-            asset_sym,
-            asset_name,
-            address_owner,
-            balance,
+            asset,
+            supply,
             r_low,
             r_high,
             s_low,
@@ -146,60 +149,39 @@ func post_data_l2{
             public_key,
         );
     }
-    let (root_) = calc_hash(0, 4, new(address_owner, asset_name, balance, timestamp));
-    roots.write(address_owner, asset_name, balance, timestamp, root_);
+   
+   let round = Round(public_key ,supply, timestamp);
+    supplies_rounds.write(asset, 1, round);
     
     return ();
 }
 
-// user call this function to verify if a address had this balance
+// gets the latest reserves round published from l1
 @view
-func verify_balance{
+func get_latest_reserves{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*, 
-        range_check_ptr,
-        ecdsa_ptr : SignatureBuiltin*
+        range_check_ptr
 }(
-    leaf: felt, merkle_root: felt, proof_len: felt, proof: felt*
-) -> (res:felt){
-    alloc_locals;
-    // calculate root
-    let (root) = calc_hash(leaf, proof_len, proof);
-    // check if the root is stored
-    if(root==merkle_root){
-        return (res=1);
-    }
-    return (res=0);
+    asset: felt
+) -> (data: Round){
+   
+    return reserves_rounds.read(asset, 1);
 }
 
-// generate hash
-func calc_hash{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    curr: felt, 
-    proof_len: felt,
-    proof: felt*
-) -> (res: felt){
-    alloc_locals;
-    if (proof_len == 0) {
-        return (res=curr);
-    }
-    local node;
-    local proof_element = [proof];
-    let le = is_le_felt(curr, proof_element);
-    if (le==1){
-        let (n) = hash2{hash_ptr=pedersen_ptr}(curr, proof_element);
-        node = n;
-    } else {
-        let (n) = hash2{hash_ptr=pedersen_ptr}(proof_element, curr);
-        node = n;
-    }
-    let (res) = calc_hash(node, proof_len-1, proof+1); 
-    return (res=res);
-}
-
-// help function to get the exact hash stored by a publisher
+// gets the latest asset supply on l2
 @view
-func get_root{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(public_key: felt, asset: felt, balance: felt, timestamp: felt) -> (res: felt) {
-    alloc_locals;
-    let (res) = roots.read(public_key, asset, balance, timestamp);
-    return (res=res);
+func get_latest_supply{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*, 
+        range_check_ptr
+}(
+    asset: felt
+) -> (data: Round){
+
+ return supplies_rounds.read(asset, 1);
+
 }
+
+
+

--- a/contracts/starknet/signature_verification.cairo
+++ b/contracts/starknet/signature_verification.cairo
@@ -39,16 +39,14 @@ func word_reverse_endian_64{bitwise_ptr: BitwiseBuiltin*}(word: felt) -> (res: f
 }
 
 func verify_signature{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(
-    asset_sym_little: felt,
-    asset_name_little: felt,
-    address_owner_little: felt,
-    balance_little: felt,
+    asset: felt,
+    reserve: felt,
     r_low: felt,
     r_high: felt,
     s_low: felt,
     s_high: felt,
     v: felt,
-    eth_address: felt,
+    eth_address: felt
 ) {
     alloc_locals;
     // keccak_ptr needs to be initialized to use the keccak functions
@@ -69,7 +67,8 @@ func verify_signature{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(
     assert input[4] = 0;  // 40
     assert input[5] = 0;  // 48
     assert input[6] = 0;  // 56
-    assert input[7] = asset_sym_little;  // 64
+    // assert input[7] = asset_sym_little;  // 64
+    assert input[7] = asset; //64
     assert input[8] = 0;  // 72
     assert input[9] = 0;  // 80
     assert input[10] = 0;  // 88
@@ -77,7 +76,7 @@ func verify_signature{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(
     assert input[12] = 0;  // 104
     assert input[13] = 0;  // 112
     assert input[14] = 0;  // 120
-    assert input[15] = asset_name_little;  // 128
+    assert input[15] = reserve; // 128
     assert input[16] = 0;  // 136
     assert input[17] = 0;  // 144
     assert input[18] = 0;  // 152
@@ -89,8 +88,8 @@ func verify_signature{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(
     assert input[24] = 0;  // 200
     assert input[25] = 0;  // 208
     assert input[26] = 0;  // 216
-    assert input[27] = address_owner_little;  // 224
-    assert input[28] = balance_little;  // 232
+    assert input[27] = 0;
+    assert input[28] = 0;
     assert input[29] = 0;  // 240
     assert input[30] = 0;  // 248
     assert input[31] = 0;  // 256


### PR DESCRIPTION
## main changes

The new workflow on L1:  
- oracle/publisher sends a payload to l2 with the asset address, total collateral and signature. 

The new workflow on L2:  
- get asset `reserves` from L1
- get the supply of the wrapped token on L2
- call the proof of reserve contract to get the latest round of answers regarding the `supply` and `reserves` of a specified asset. ⚠️ Supply should always be lower than or equal to reserves. 

## To do

- [x] update `verify_signature` function
- [x] update tests
- [x] increment round id
- [x] add system architecture diagram
- [x] format code

